### PR TITLE
seller의 CRUD를 구현중입니다!

### DIFF
--- a/data-source.ts
+++ b/data-source.ts
@@ -15,10 +15,7 @@ export default new DataSource({
   username: process.env[`${NODE_ENV}_DB_USERNAME`] as string,
   database: process.env[`${NODE_ENV}_DB_DATABASE`] as string,
   password: process.env[`${NODE_ENV}_DB_PASSWORD`] as string,
-  entities: [
-    path.join(__dirname, './src/entities/*.entity.ts'),
-    path.join(__dirname, './src/entities/*.entity.js'),
-  ],
+  entities: [path.join(__dirname, './src/entities/*.entity.ts'), path.join(__dirname, './src/entities/*.entity.js')],
   synchronize: false,
   logging: true,
   namingStrategy: new SnakeNamingStrategy(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.1.16",
         "@nestjs/typeorm": "^10.0.0",
         "@types/passport-jwt": "^3.0.13",
         "bcryptjs": "^2.4.3",
@@ -1710,6 +1711,25 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.3.tgz",
+      "integrity": "sha512-40Zdqg98lqoF0+7ThWIZFStxgzisK6GG22+1ABO4kZiGF/Tu2FE+DYLw+Q9D94vcFWizJ+MSjNN4ns9r6hIGxw==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.2.tgz",
@@ -1753,6 +1773,37 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.2"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.1.16.tgz",
+      "integrity": "sha512-f9KBk/BX9MUKPTj7tQNYJ124wV/jP5W2lwWHLGwe/4qQXixuDOo39zP55HIJ44LE7S04B7BOeUOo9GBJD/vRcw==",
+      "dependencies": {
+        "@nestjs/mapped-types": "2.0.3",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.9.1"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2786,8 +2837,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -7039,7 +7089,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -9477,6 +9526,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.9.1.tgz",
+      "integrity": "sha512-5zAx+hUwJb9T3EAntc7TqYkV716CMqG6sZpNlAAMOMWkNXRYxGkN8ADIvD55dQZ10LxN90ZM/TQmN7y1gpICnw=="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.1.16",
     "@nestjs/typeorm": "^10.0.0",
     "@types/passport-jwt": "^3.0.13",
     "bcryptjs": "^2.4.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { ProductModule } from './modules/product.module';
 
 @Module({
   imports: [
@@ -9,6 +10,7 @@ import { ConfigModule } from '@nestjs/config';
       cache: true,
       isGlobal: true,
     }),
+    ProductModule,
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { ProductModule } from './modules/product.module';
+import { SellerModule } from './modules/seller.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { ProductModule } from './modules/product.module';
       isGlobal: true,
     }),
     ProductModule,
+    SellerModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -16,7 +16,7 @@ export class AuthService {
 
   // email-password를 받아 회원 가입
   async signUp(authCredentialsDto: AuthCredentialsDto): Promise<void> {
-    const { email, password } = authCredentialsDto;
+    const { email, hashedPassword: password } = authCredentialsDto;
     const user = await this.userRespository.findOneBy({ email });
     if (user) {
       // 등록된 유저라면 error
@@ -31,7 +31,7 @@ export class AuthService {
 
   // email-password을 받아 등록된 유저인지 확인후 토큰 반환
   async signIn(authCredentialsDto: AuthCredentialsDto): Promise<AccessToken> {
-    const { email, password } = authCredentialsDto;
+    const { email, hashedPassword: password } = authCredentialsDto;
     const user = await this.userRespository.findOneBy({ email });
 
     // 등록된 유저인지 확인

--- a/src/controllers/boards.controller.ts
+++ b/src/controllers/boards.controller.ts
@@ -19,14 +19,20 @@ import { BoardStatusValidationPipe } from '../pipes/board-status-vaildation.pipe
 import { BoardEntity } from 'src/entities/board.entity';
 import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
 import { UserId } from 'src/auth/userid.decorator';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @UseGuards(JwtAuthGuard)
 @Controller('boards')
+@ApiTags('Board API')
 export class BoardsController {
   private logger = new Logger('Board');
   constructor(private readonly boardsSevice: BoardsService) {}
 
   @Get('/')
+  @ApiOperation({
+    summary: 'User Id 로 Board 가져오기 API',
+    description: 'User Id로 해당 User가 작성한 board를 가져온다.',
+  })
   async getBoardByUserId(@UserId() id: number): Promise<BoardEntity[]> {
     this.logger.verbose(`User ${id} trying to get all boards`);
     return await this.boardsSevice.getBoardByUserId(id);
@@ -34,22 +40,26 @@ export class BoardsController {
 
   @Post('/')
   @UsePipes(ValidationPipe)
+  @ApiOperation({ summary: 'Board 생성 API', description: '현재 User의 board를 생성한다.' })
   async createBoard(@Body() createBoardDto: CreateBoardDto, @UserId() id: number): Promise<BoardEntity> {
     this.logger.verbose(`User ${id} creating a new board. Payload: ${JSON.stringify(createBoardDto)}`);
     return await this.boardsSevice.createBoard(createBoardDto, id);
   }
 
   @Get('/:id')
+  @ApiOperation({ summary: 'Board Id로 Board 가져오기 API', description: '해당 Id를 가진 board를 가져온다.' })
   async getBoardById(@Param('id', ParseIntPipe) id: number): Promise<BoardEntity> {
     return await this.boardsSevice.getBoardById(id);
   }
 
   @Delete('/:id')
+  @ApiOperation({ summary: 'Board 삭제하기 API', description: '현재 User가 작성한 게시물들을 id로 삭제한다.' })
   async deleteBoard(@Param('id', ParseIntPipe) boardId: number, @UserId() userId: number): Promise<boolean> {
     return await this.boardsSevice.deleteBoard(boardId, userId);
   }
 
   @Patch('/:id/status')
+  @ApiOperation({ summary: 'Board 공개 여부 갱신하기', description: '해당 id를 가진 board의 상태를 변경' })
   async updateBoardStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body('status', BoardStatusValidationPipe) status: BoardStatus,

--- a/src/controllers/product.controller.ts
+++ b/src/controllers/product.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('product')
+export class ProductController {}

--- a/src/controllers/seller.controller.ts
+++ b/src/controllers/seller.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('seller')
+export class SellerController {}

--- a/src/controllers/seller.controller.ts
+++ b/src/controllers/seller.controller.ts
@@ -1,4 +1,14 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
+import { SellerEntity } from 'src/entities/seller.entity';
+import { SellerService } from 'src/services/seller.service';
 
 @Controller('seller')
-export class SellerController {}
+export class SellerController {
+  constructor(private readonly sellerService: SellerService) {}
+
+  @Post('/')
+  async createSeller(@Body() createSellerDto: CreateSellerDto): Promise<SellerEntity> {
+    return await this.sellerService.createSeller(createSellerDto);
+  }
+}

--- a/src/controllers/seller.controller.ts
+++ b/src/controllers/seller.controller.ts
@@ -1,13 +1,16 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
 import { SellerEntity } from 'src/entities/seller.entity';
 import { SellerService } from 'src/services/seller.service';
 
 @Controller('seller')
+@ApiTags('Seller API')
 export class SellerController {
   constructor(private readonly sellerService: SellerService) {}
 
   @Post('/')
+  @ApiOperation({ summary: 'Seller 생성 API', description: 'Seller를 생성한다.' })
   async createSeller(@Body() createSellerDto: CreateSellerDto): Promise<SellerEntity> {
     return await this.sellerService.createSeller(createSellerDto);
   }

--- a/src/entities/company.entity.ts
+++ b/src/entities/company.entity.ts
@@ -7,6 +7,12 @@ export class CompanyEntity extends CommonEntity {
   @Column({ type: 'varchar', length: 128 })
   name!: string;
 
+  @Column({ type: 'varchar', length: 128, unique: true })
+  email!: string;
+
+  @Column({ type: 'varchar', length: 11, nullable: true })
+  phone!: string;
+
   /**
    * relations
    */

--- a/src/entities/dtos/auth-credentials.dto.ts
+++ b/src/entities/dtos/auth-credentials.dto.ts
@@ -9,5 +9,5 @@ export class AuthCredentialsDto {
   @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/, {
     message: '비밀번호 조건에 맞지 않음',
   })
-  password!: string;
+  hashedPassword!: string;
 }

--- a/src/entities/dtos/auth-credentials.dto.ts
+++ b/src/entities/dtos/auth-credentials.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, Matches, MaxLength, MinLength } from 'class-validator';
 
 export class AuthCredentialsDto {
+  @ApiProperty()
   @IsEmail()
   email!: string;
 
+  @ApiProperty()
   @IsString()
   @MaxLength(20)
   @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/, {

--- a/src/entities/dtos/create-board.dto.ts
+++ b/src/entities/dtos/create-board.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 
 export class CreateBoardDto {
+  @ApiProperty()
   @IsNotEmpty()
   title!: string;
 
+  @ApiProperty()
   @IsNotEmpty()
   description!: string;
 }

--- a/src/entities/dtos/create-product.dto.ts
+++ b/src/entities/dtos/create-product.dto.ts
@@ -1,0 +1,24 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class CreateBoardDto {
+  @IsNotEmpty()
+  bundleId!: number;
+
+  @IsNotEmpty()
+  categoryId!: number;
+
+  @IsNotEmpty()
+  companyId!: number;
+
+  @IsNotEmpty()
+  title!: string;
+
+  @IsNotEmpty()
+  price!: number;
+
+  @IsNotEmpty()
+  description!: string;
+
+  @IsNotEmpty()
+  shippingFee!: number;
+}

--- a/src/entities/dtos/create-product.dto.ts
+++ b/src/entities/dtos/create-product.dto.ts
@@ -1,6 +1,6 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsOptional } from 'class-validator';
 
-export class CreateBoardDto {
+export class CreateProductDto {
   @IsNotEmpty()
   bundleId!: number;
 
@@ -16,7 +16,7 @@ export class CreateBoardDto {
   @IsNotEmpty()
   price!: number;
 
-  @IsNotEmpty()
+  @IsOptional()
   description!: string;
 
   @IsNotEmpty()

--- a/src/entities/dtos/create-seller.dto.ts
+++ b/src/entities/dtos/create-seller.dto.ts
@@ -1,16 +1,20 @@
 import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
 import { AuthCredentialsDto } from './auth-credentials.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateSellerDto extends AuthCredentialsDto {
+  @ApiProperty()
   @IsNotEmpty()
   @IsString()
   name!: string;
 
+  @ApiProperty()
   @IsNotEmpty()
   @IsString()
   @MaxLength(11)
   phone!: string;
 
+  @ApiProperty()
   @IsNotEmpty()
   @IsString()
   businessNumber!: string;

--- a/src/entities/dtos/create-seller.dto.ts
+++ b/src/entities/dtos/create-seller.dto.ts
@@ -1,0 +1,17 @@
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { AuthCredentialsDto } from './auth-credentials.dto';
+
+export class CreateSellerDto extends AuthCredentialsDto {
+  @IsNotEmpty()
+  @IsString()
+  name!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(11)
+  phone!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  businessNumber!: string;
+}

--- a/src/entities/seller.entity.ts
+++ b/src/entities/seller.entity.ts
@@ -4,16 +4,16 @@ import { ProductBundleEntity } from './product-bundle.entity';
 
 @Entity({ name: 'seller' })
 export class SellerEntity extends CommonEntity {
+  @Column({ type: 'varchar', length: 128, unique: true })
+  email!: string;
+
   @Column({ type: 'varchar', length: 512 })
   hashedPassword!: string;
 
   @Column({ type: 'varchar', length: 32 })
   name!: string;
 
-  @Column({ type: 'varchar', length: 128, unique: true })
-  email!: string;
-
-  /* - 기호는 포함하지 않습니다 */
+  /* - 는 포함하지 않습니다 */
   @Column({ type: 'varchar', length: 11 })
   phone!: string;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger } from '@nestjs/common';
+import { setupSwagger } from './util/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const port = 3000;
+  setupSwagger(app);
+
   await app.listen(port);
+
   Logger.log(`Application running on port ${port}`);
 }
 bootstrap();

--- a/src/modules/product.module.ts
+++ b/src/modules/product.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProductController } from '../controllers/product.controller';
+import { ProductService } from '../services/product.service';
+
+@Module({
+  controllers: [ProductController],
+  providers: [ProductService],
+})
+export class ProductModule {}

--- a/src/modules/seller.module.ts
+++ b/src/modules/seller.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SellerController } from '../controllers/seller.controller';
 import { SellerService } from '../services/seller.service';
+import { SellerRespository } from 'src/repositories/seller.repository';
+import { CustomTypeOrmModule } from 'src/configs/custom-typeorm.module';
 
 @Module({
+  imports: [CustomTypeOrmModule.forCustomRepository([SellerRespository])],
   controllers: [SellerController],
   providers: [SellerService],
 })

--- a/src/modules/seller.module.ts
+++ b/src/modules/seller.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SellerController } from '../controllers/seller.controller';
+import { SellerService } from '../services/seller.service';
+
+@Module({
+  controllers: [SellerController],
+  providers: [SellerService],
+})
+export class SellerModule {}

--- a/src/repositories/seller.repository.ts
+++ b/src/repositories/seller.repository.ts
@@ -1,0 +1,6 @@
+import { CustomRepository } from '../configs/custom-typeorm.decorator';
+import { Repository } from 'typeorm';
+import { SellerEntity } from 'src/entities/seller.entity';
+
+@CustomRepository(SellerEntity)
+export class SellerRespository extends Repository<SellerEntity> {}

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,9 +1,6 @@
 import { CustomRepository } from '../configs/custom-typeorm.decorator';
 import { Repository } from 'typeorm';
 import { UserEntity } from 'src/entities/user.entity';
-import { AuthCredentialsDto } from 'src/entities/dtos/auth-credentials.dto';
 
 @CustomRepository(UserEntity)
-export class UserRespository extends Repository<UserEntity> {
-  async createUser(authCredentialsDto: AuthCredentialsDto): Promise<void> {}
-}
+export class UserRespository extends Repository<UserEntity> {}

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ProductService {}

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SellerService {}

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -1,4 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
+import { SellerEntity } from 'src/entities/seller.entity';
+import { SellerRespository } from 'src/repositories/seller.repository';
+import * as bcrypt from 'bcryptjs';
 
 @Injectable()
-export class SellerService {}
+export class SellerService {
+  constructor(
+    @InjectRepository(SellerRespository)
+    private readonly sellerRepository: SellerRespository,
+  ) {}
+
+  // seller 생성
+  async createSeller(createSellerDto: CreateSellerDto): Promise<SellerEntity> {
+    const seller = await this.sellerRepository.findOneBy({ email: createSellerDto.email });
+    if (seller) {
+      throw new UnauthorizedException('this email already exists');
+    }
+
+    const salt = await bcrypt.genSalt();
+    createSellerDto.hashedPassword = await bcrypt.hash(createSellerDto.hashedPassword, salt);
+    return await this.sellerRepository.save({
+      ...createSellerDto,
+    });
+  }
+}

--- a/src/test/seller.controller.spec.ts
+++ b/src/test/seller.controller.spec.ts
@@ -2,14 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { SellerController } from '../controllers/seller.controller';
 import { SellerService } from 'src/services/seller.service';
 import { SellerEntity } from 'src/entities/seller.entity';
+import { AuthCredentialsDto } from 'src/entities/dtos/auth-credentials.dto';
+import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
+import { AppModule } from 'src/app.module';
 
 describe('SellerController', () => {
   let controller: SellerController;
   let service: SellerService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      controllers: [SellerController],
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+      controllers: [],
+      providers: [],
     }).compile();
 
     controller = module.get<SellerController>(SellerController);
@@ -26,6 +31,7 @@ describe('SellerController', () => {
     expect(response instanceof SellerEntity).toBe(true);
   });
 
+  /*
   it('controller.getSellerById는 Seller의 name과 email, phone를 리턴해야 한다.', async () => {
     const response = controller.getSellerById();
     expect(response.name).toBeDefined();
@@ -38,4 +44,5 @@ describe('SellerController', () => {
     expect(response.length).toBeDefined();
     expect(response instanceof Array).toBe(true);
   });
+  */
 });

--- a/src/test/seller.controller.spec.ts
+++ b/src/test/seller.controller.spec.ts
@@ -1,0 +1,41 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SellerController } from '../controllers/seller.controller';
+import { SellerService } from 'src/services/seller.service';
+import { SellerEntity } from 'src/entities/seller.entity';
+
+describe('SellerController', () => {
+  let controller: SellerController;
+  let service: SellerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SellerController],
+    }).compile();
+
+    controller = module.get<SellerController>(SellerController);
+    service = module.get<SellerService>(SellerService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+    expect(service).toBeDefined();
+  });
+
+  it('controller.createSeller는 SellerEntity을 리턴해야 한다.', async () => {
+    const response = controller.createSeller();
+    expect(response instanceof SellerEntity).toBe(true);
+  });
+
+  it('controller.getSellerById는 Seller의 name과 email, phone를 리턴해야 한다.', async () => {
+    const response = controller.getSellerById();
+    expect(response.name).toBeDefined();
+    expect(response.email).toBeDefined();
+    expect(response.phone).toBeDefined();
+  });
+
+  it('controller.getAllSeller는 배열을 리턴해야 한다.', async () => {
+    const response = controller.getAllSeller();
+    expect(response.length).toBeDefined();
+    expect(response instanceof Array).toBe(true);
+  });
+});

--- a/src/test/seller.controller.spec.ts
+++ b/src/test/seller.controller.spec.ts
@@ -31,25 +31,29 @@ describe('SellerController', () => {
   판매자는 email, 비밀번호, 이름, 핸드폰번호, 사업자 번호을 입력해야 회원가입 할 수 있다.
   판매자는 email과 비밀번호로 로그인된다.
   email은 중복되면 안된다.
-  핸드폰, 사업자번호는 실제 있는 번호인지 검증이 필요
+  핸드폰, 사업자번호는 실제 있는 번호인지 검증이 필요...
 
 */
 
   it('판매자는 email, 비밀번호, 이름, 핸드폰번호, 사업자 번호를 입력해야 회원가입 할 수 있다.', async () => {
-    const response = await controller.createSeller();
-    expect(response.email).toBe(String);
-    expect(response.hashedPassword).toBe(String);
-    expect(response.name).toBe(String);
-    expect(response.phone).toBe(String);
-    expect(response.businessNumber).toBe(String);
+    const createSellerDto = new CreateSellerDto();
+    createSellerDto.email = 'abc123@gmail.com';
+    createSellerDto.hashedPassword = 'abc000!';
+    createSellerDto.name = 'abc';
+    createSellerDto.phone = '00011110000';
+    createSellerDto.businessNumber = '000000000';
+
+    await controller.createSeller(createSellerDto);
   });
 
   /*
     판매자 조회
   판매자는 자신의 email, 이름, 핸드폰번호, 사업자 번호를 열람 할 수 있어야 한다.
 */
-  it('판매자는 자신의 email, 이름, 핸드폰번호, 사업자 번호를 열람 할 수 있어야 한다.', async () => {
-    const response = await controller.getSeller();
+
+  it('판매자는 id로 자신의 email, 이름, 핸드폰번호, 사업자 번호를 열람 할 수 있어야 한다.', async () => {
+    const id = 0;
+    const response = await controller.getSeller(id);
     expect(response.email).toBe(String);
     expect(response.name).toBe(String);
     expect(response.phone).toBe(String);

--- a/src/test/seller.controller.spec.ts
+++ b/src/test/seller.controller.spec.ts
@@ -26,23 +26,67 @@ describe('SellerController', () => {
     expect(service).toBeDefined();
   });
 
-  it('controller.createSeller는 SellerEntity을 리턴해야 한다.', async () => {
-    const response = controller.createSeller();
-    expect(response instanceof SellerEntity).toBe(true);
+  /*
+    판매자 등록 
+  판매자는 email, 비밀번호, 이름, 핸드폰번호, 사업자 번호을 입력해야 회원가입 할 수 있다.
+  판매자는 email과 비밀번호로 로그인된다.
+  email은 중복되면 안된다.
+  핸드폰, 사업자번호는 실제 있는 번호인지 검증이 필요
+
+*/
+
+  it('판매자는 email, 비밀번호, 이름, 핸드폰번호, 사업자 번호를 입력해야 회원가입 할 수 있다.', async () => {
+    const response = await controller.createSeller();
+    expect(response.email).toBe(String);
+    expect(response.hashedPassword).toBe(String);
+    expect(response.name).toBe(String);
+    expect(response.phone).toBe(String);
+    expect(response.businessNumber).toBe(String);
   });
 
   /*
-  it('controller.getSellerById는 Seller의 name과 email, phone를 리턴해야 한다.', async () => {
-    const response = controller.getSellerById();
-    expect(response.name).toBeDefined();
-    expect(response.email).toBeDefined();
-    expect(response.phone).toBeDefined();
+    판매자 조회
+  판매자는 자신의 email, 이름, 핸드폰번호, 사업자 번호를 열람 할 수 있어야 한다.
+*/
+  it('판매자는 자신의 email, 이름, 핸드폰번호, 사업자 번호를 열람 할 수 있어야 한다.', async () => {
+    const response = await controller.getSeller();
+    expect(response.email).toBe(String);
+    expect(response.name).toBe(String);
+    expect(response.phone).toBe(String);
+    expect(response.businessNumber).toBe(String);
   });
 
-  it('controller.getAllSeller는 배열을 리턴해야 한다.', async () => {
-    const response = controller.getAllSeller();
-    expect(response.length).toBeDefined();
-    expect(response instanceof Array).toBe(true);
-  });
+  /*
+    판매자 수정
+  판매자는 이름, 핸드폰번호, 사업자 번호를 수정할 수 있어야 한다.
+  판매자는  비밀번호를 갱신 할 수 있어야 한다.
+  
   */
+
+  it('판매자는 이름 || 핸드폰번호 || 사업자 번호를 수정할 수 있어야 한다.', async () => {
+    const before = await controller.getSeller();
+
+    await controller.updateSeller({
+      name: 'test',
+    });
+
+    const after = await controller.getSeller();
+    expect(before.updateAt < after.updateAt).toBe(true);
+  });
+
+  it('판매자는 비밀번호를 갱신 할 수 있어야 한다.', async () => {
+    const response = await controller.updatePasswordSeller();
+    expect(response.hashedPassword).toBe(String);
+  });
+
+  /*
+    판매자 삭제
+  판매자가 삭제되면? 판매자의 번들과 상품들이 모두 검색 불가처리
+  이미 구매한 사람들에게는 -> 판매 중지 제품 페이지로 연결
+  해당 id의 delete_at에 값이 들어가야한다.
+*/
+  it('해당 id의 delete_at에 값이 들어가야한다.', async () => {
+    const response = await controller.deleteSeller();
+    expect(response.deleteAt !== null).toBe(true);
+  });
 });

--- a/src/util/swagger.ts
+++ b/src/util/swagger.ts
@@ -1,0 +1,17 @@
+import { INestApplication } from '@nestjs/common';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+/**
+ * Swagger 세팅
+ *
+ * @param {INestApplication} app
+ */
+export function setupSwagger(app: INestApplication): void {
+  const options = new DocumentBuilder()
+    .setTitle('NestJS Study API Docs')
+    .setDescription('NestJS Study API description')
+    .setVersion('1.0.0')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, options);
+  SwaggerModule.setup('api-docs', app, document);
+}


### PR DESCRIPTION
## Background(배경지식)
강의에서 배웠던 내용을 바탕으로 모듈을 생성하고 CRUD 서비스를 추가하고 있습니다.


## Implementations(보충설명)
1. Seller Entity 수정
2. Seller 모듈 생성
3. 테스트 케이스 작성
4. Seller Repositoy 및 DTO 생성 (Auth Dto를 extends)
5. createSeller 컨트롤러 및 서비스 추가

짧게나마 테스트 코드를 작성하고 이를 통과하는 서비스를 구현하였는데, 원하는대로 구현은 되었으나

테스트 코드는 통과하지 못했습니다.


## Other (Optional)

컨트롤러의 `createSeller()`는 다음과 같습니다.
```ts
  @Post('/')
  async createSeller(@Body() createSellerDto: CreateSellerDto): Promise<SellerEntity> {
    return await this.sellerService.createSeller(createSellerDto);
  }
```


테스트 코드는 단순히 response 되는 타입이 SellerEntity가 맞는지 확인하는 것인데, 

createSellerDto를 인수로 어떻게 넘겨줘야하는지 모르겠습니다.


``` ts
  it('controller.createSeller는 SellerEntity을 리턴해야 한다.', async () => {
    const response = controller.createSeller();
    expect(response instanceof SellerEntity).toBe(true);
  });
```

직접 객체를 넣어서도 테스트 해봤는데,  `SellerEntity`를 찾을수 없다고 오류가 나오더군요. 

애초에 엔티티는 타입을 검사할 수 없는건지 궁금합니다. 

아니면 create 기능을 테스트 하려는게 이상한건가요... 😂 

