### PR TITLE
#46 코멘트 내용을 반영했습니다!

### DIFF
--- a/data-source.ts
+++ b/data-source.ts
@@ -1,7 +1,7 @@
 // ./data-source.ts
-import { DataSource } from 'typeorm';
 import * as dotenv from 'dotenv';
 import * as path from 'path';
+import { DataSource } from 'typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 dotenv.config();
@@ -15,10 +15,7 @@ export default new DataSource({
   username: process.env[`${NODE_ENV}_DB_USERNAME`] as string,
   database: process.env[`${NODE_ENV}_DB_DATABASE`] as string,
   password: process.env[`${NODE_ENV}_DB_PASSWORD`] as string,
-  entities: [
-    path.join(__dirname, './src/entities/*.entity.ts'),
-    path.join(__dirname, './src/entities/*.entity.js'),
-  ],
+  entities: [path.join(__dirname, './src/entities/*.entity.ts'), path.join(__dirname, './src/entities/*.entity.js')],
   synchronize: false,
   logging: true,
   namingStrategy: new SnakeNamingStrategy(),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
-import { Module } from '@nestjs/common';
+import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { APP_PIPE } from '@nestjs/core';
 import { AuthModule } from './auth/auth.module';
 
 @Module({
@@ -9,6 +10,12 @@ import { AuthModule } from './auth/auth.module';
       cache: true,
       isGlobal: true,
     }),
+  ],
+  providers: [
+    {
+      provide: APP_PIPE,
+      useClass: ValidationPipe,
+    },
   ],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,16 +1,12 @@
 import { Body, Controller, Get, Post, Req, UseGuards, ValidationPipe } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { AuthCredentialsDto } from 'src/entities/dtos/auth-credentials.dto';
 import { CreateBuyerDto } from 'src/entities/dtos/create-buyer.dto';
 import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
-import { AccessToken } from 'src/interfaces/access-token';
 import { AuthService } from './auth.service';
 import { BuyerLocalAuthGuard } from './guards/buyer-local.auth.guard';
 import { BuyerJwtAuthGuard } from './guards/buyer.jwt.guard';
 import { SellerLocalAuthGuard } from './guards/seller-local.auth.guard';
 import { SellerJwtAuthGuard } from './guards/seller.jwt.guard';
-import { UserId } from './userid.decorator';
 
 @Controller('auth')
 @ApiTags('로그인 API')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Req, UseGuards, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateBuyerDto } from 'src/entities/dtos/create-buyer.dto';
 import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
@@ -16,7 +16,7 @@ export class AuthController {
   // buyer 회원가입
   @Post('/signup')
   @ApiOperation({ summary: 'buyer 생성 API', description: 'buyer를 생성한다.' })
-  async buyerSignUp(@Body(ValidationPipe) createUserDto: CreateBuyerDto): Promise<void> {
+  async buyerSignUp(@Body() createUserDto: CreateBuyerDto): Promise<void> {
     await this.authService.buyerSignUp(createUserDto);
   }
 
@@ -32,7 +32,7 @@ export class AuthController {
   // 판매자 회원가입
   @Post('/signup-seller')
   @ApiOperation({ summary: 'seller 생성 API', description: 'seller 생성한다.' })
-  async sellerSignUp(@Body(ValidationPipe) createSellerDto: CreateSellerDto): Promise<void> {
+  async sellerSignUp(@Body() createSellerDto: CreateSellerDto): Promise<void> {
     await this.authService.sellerSignUp(createSellerDto);
   }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,11 +2,16 @@ import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateBuyerDto } from 'src/entities/dtos/create-buyer.dto';
 import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
+import { AccessToken } from 'src/interfaces/access-token';
+import { BuyerAuthResult } from 'src/interfaces/buyer-auth-result';
+import { Payload } from 'src/interfaces/payload';
+import { SellerAuthResult } from 'src/interfaces/seller-auth-result';
 import { AuthService } from './auth.service';
 import { BuyerLocalAuthGuard } from './guards/buyer-local.auth.guard';
 import { BuyerJwtAuthGuard } from './guards/buyer.jwt.guard';
 import { SellerLocalAuthGuard } from './guards/seller-local.auth.guard';
 import { SellerJwtAuthGuard } from './guards/seller.jwt.guard';
+import { User } from './user.decorator';
 
 @Controller('auth')
 @ApiTags('로그인 API')
@@ -24,9 +29,8 @@ export class AuthController {
   @UseGuards(BuyerLocalAuthGuard)
   @Post('/signin')
   @ApiOperation({ summary: 'buyer 로그인 API', description: 'buyer 비밀번호 매칭' })
-  buyerSignIn(@Req() req) {
-    // console.log(req.user);
-    return this.authService.buyerLogin(req.user);
+  buyerSignIn(@User() user: BuyerAuthResult) {
+    return this.authService.buyerLogin(user);
   }
 
   // 판매자 회원가입
@@ -40,20 +44,19 @@ export class AuthController {
   @UseGuards(SellerLocalAuthGuard)
   @Post('/signin-seller')
   @ApiOperation({ summary: 'seller 로그인 API', description: 'seller 비밀번호 매칭' })
-  sellerSignIn(@Req() req) {
-    console.log(req.user);
-    return this.authService.sellrLogin(req.user);
+  sellerSignIn(@User() user: SellerAuthResult) {
+    return this.authService.sellrLogin(user);
   }
 
   @UseGuards(BuyerJwtAuthGuard)
   @Get('/mypage')
-  getMyPage(@Req() req) {
-    return req.user;
+  getMyPage(@User() user: BuyerAuthResult) {
+    return user;
   }
 
   @UseGuards(SellerJwtAuthGuard)
   @Get('/seller-page')
-  getSellerPage(@Req() req) {
-    return req.user;
+  getSellerPage(@User() user: SellerAuthResult) {
+    return user;
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AuthCredentialsDto } from 'src/entities/dtos/auth-credentials.dto';
 import { CreateBuyerDto } from 'src/entities/dtos/create-buyer.dto';
 import { CreateSellerDto } from 'src/entities/dtos/create-seller.dto';
 import { AccessToken } from 'src/interfaces/access-token';
@@ -29,7 +30,7 @@ export class AuthController {
   @UseGuards(BuyerLocalAuthGuard)
   @Post('/signin')
   @ApiOperation({ summary: 'buyer 로그인 API', description: 'buyer 비밀번호 매칭' })
-  buyerSignIn(@User() user: BuyerAuthResult) {
+  buyerSignIn(@Body() authCredentialsDto: AuthCredentialsDto, @User() user: BuyerAuthResult) {
     return this.authService.buyerLogin(user);
   }
 
@@ -44,7 +45,7 @@ export class AuthController {
   @UseGuards(SellerLocalAuthGuard)
   @Post('/signin-seller')
   @ApiOperation({ summary: 'seller 로그인 API', description: 'seller 비밀번호 매칭' })
-  sellerSignIn(@User() user: SellerAuthResult) {
+  sellerSignIn(@Body() authCredentialsDto: AuthCredentialsDto, @User() user: SellerAuthResult) {
     return this.authService.sellrLogin(user);
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,5 +1,5 @@
-import * as bcrypt from 'bcryptjs';
-import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
+import bcrypt from 'bcryptjs';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AuthCredentialsDto } from 'src/entities/dtos/auth-credentials.dto';

--- a/src/auth/strategies/buyer.jwt.strategy.ts
+++ b/src/auth/strategies/buyer.jwt.strategy.ts
@@ -1,5 +1,5 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';

--- a/src/auth/strategies/buyer.jwt.strategy.ts
+++ b/src/auth/strategies/buyer.jwt.strategy.ts
@@ -3,6 +3,7 @@ import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@n
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Payload } from 'src/interfaces/payload';
 import { BuyersRespository } from 'src/repositories/buyers.repository';
 
 @Injectable()
@@ -18,13 +19,12 @@ export class BuyerJwtStrategy extends PassportStrategy(Strategy, 'buyer-jwt') {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: Payload) {
     const { id } = payload;
     const member = await this.buyersRespository.findOneBy({ id });
     if (member) {
       return { id };
-    } else {
-      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
     }
+    throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
   }
 }

--- a/src/auth/strategies/buyer.local.strategy.ts
+++ b/src/auth/strategies/buyer.local.strategy.ts
@@ -1,5 +1,5 @@
 import { Strategy } from 'passport-local';
-import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { BuyerAuthResult } from 'src/interfaces/buyer-auth-result';
 import { AuthService } from '../auth.service';

--- a/src/auth/strategies/buyer.local.strategy.ts
+++ b/src/auth/strategies/buyer.local.strategy.ts
@@ -1,5 +1,5 @@
 import { Strategy } from 'passport-local';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { BuyerAuthResult } from 'src/interfaces/buyer-auth-result';
 import { AuthService } from '../auth.service';
@@ -13,7 +13,7 @@ export class BuyerLocalStrategy extends PassportStrategy(Strategy, 'buyer-local'
   async validate(email: string, password: string): Promise<BuyerAuthResult> {
     const user = await this.authService.validateBuyer({ email, password });
     if (!user) {
-      throw new UnauthorizedException();
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
     }
     return user;
   }

--- a/src/auth/strategies/seller.jwt.strategy.ts
+++ b/src/auth/strategies/seller.jwt.strategy.ts
@@ -3,6 +3,7 @@ import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@n
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Payload } from 'src/interfaces/payload';
 import { SellersRespository } from 'src/repositories/sellers.repository';
 
 @Injectable()
@@ -18,13 +19,12 @@ export class SellerJwtStrategy extends PassportStrategy(Strategy, 'seller-jwt') 
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: Payload) {
     const { id } = payload;
     const member = await this.sellersRespository.findOneBy({ id });
     if (member) {
       return { id };
-    } else {
-      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
     }
+    throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
   }
 }

--- a/src/auth/strategies/seller.local.strategy.ts
+++ b/src/auth/strategies/seller.local.strategy.ts
@@ -1,5 +1,5 @@
 import { Strategy } from 'passport-local';
-import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { SellerAuthResult } from 'src/interfaces/seller-auth-result';
 import { AuthService } from '../auth.service';

--- a/src/auth/strategies/seller.local.strategy.ts
+++ b/src/auth/strategies/seller.local.strategy.ts
@@ -1,5 +1,5 @@
 import { Strategy } from 'passport-local';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { SellerAuthResult } from 'src/interfaces/seller-auth-result';
 import { AuthService } from '../auth.service';
@@ -13,7 +13,7 @@ export class SellerLocalStrategy extends PassportStrategy(Strategy, 'seller-loca
   async validate(email: string, password: string): Promise<SellerAuthResult> {
     const user = await this.authService.validateSeller({ email, password });
     if (!user) {
-      throw new UnauthorizedException();
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
     }
     return user;
   }

--- a/src/auth/user.decorator.ts
+++ b/src/auth/user.decorator.ts
@@ -1,0 +1,6 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+
+export const User = createParamDecorator((data, ctx: ExecutionContext): number => {
+  const req = ctx.switchToHttp().getRequest();
+  return req.user;
+});

--- a/src/entities/buyer.entity.ts
+++ b/src/entities/buyer.entity.ts
@@ -12,16 +12,16 @@ export class BuyerEntity extends CommonEntity {
   @Column({ type: 'varchar', length: 512 })
   hashedPassword!: string;
 
-  @Column({ type: 'varchar', length: 128, nullable: true })
+  @Column({ type: 'varchar', length: 128 })
   name!: string;
 
-  @Column({ type: 'tinyint', nullable: true })
+  @Column({ type: 'tinyint' })
   gender!: number;
 
-  @Column({ type: 'int', nullable: true })
+  @Column({ type: 'int' })
   age!: number;
 
-  @Column({ type: 'varchar', length: 11, nullable: true })
+  @Column({ type: 'varchar', length: 11 })
   phone!: string;
 
   /**

--- a/src/entities/dtos/create-buyer.dto.ts
+++ b/src/entities/dtos/create-buyer.dto.ts
@@ -1,21 +1,21 @@
-import { Optional } from '@nestjs/common';
+import { IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { AuthCredentialsDto } from './auth-credentials.dto';
 
 export class CreateBuyerDto extends AuthCredentialsDto {
   @ApiProperty({ description: '이름' })
-  @Optional()
+  @IsNotEmpty()
   name!: string;
 
   @ApiProperty({ description: '성별' })
-  @Optional()
+  @IsNotEmpty()
   gender!: number;
 
   @ApiProperty({ description: '나이' })
-  @Optional()
+  @IsNotEmpty()
   age!: number;
 
-  @ApiProperty({ description: '휴대전화번호' })
-  @Optional()
+  @ApiProperty({ description: '휴대전화번호 ( - 는 포함하지 않습니다 )' })
+  @IsNotEmpty()
   phone!: string;
 }

--- a/src/entities/dtos/create-seller.dto.ts
+++ b/src/entities/dtos/create-seller.dto.ts
@@ -1,17 +1,18 @@
+import { IsNotEmpty } from 'class-validator';
 import { Optional } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { AuthCredentialsDto } from './auth-credentials.dto';
 
 export class CreateSellerDto extends AuthCredentialsDto {
   @ApiProperty({ description: '이름' })
-  @Optional()
+  @IsNotEmpty()
   name!: string;
 
-  @ApiProperty({ description: '대표번호' })
-  @Optional()
+  @ApiProperty({ description: '대표번호 ( - 는 포함하지 않습니다 )' })
+  @IsNotEmpty()
   phone!: string;
 
   @ApiProperty({ description: '사업자등록번호' })
-  @Optional()
+  @IsNotEmpty()
   businessNumber!: string;
 }

--- a/src/entities/seller.entity.ts
+++ b/src/entities/seller.entity.ts
@@ -10,14 +10,13 @@ export class SellerEntity extends CommonEntity {
   @Column({ type: 'varchar', length: 512 })
   hashedPassword!: string;
 
-  @Column({ type: 'varchar', length: 32, nullable: true })
+  @Column({ type: 'varchar', length: 32 })
   name!: string;
 
-  /* - 기호는 포함하지 않습니다 */
-  @Column({ type: 'varchar', length: 11, nullable: true })
+  @Column({ type: 'varchar', length: 11 })
   phone!: string;
 
-  @Column({ type: 'varchar', length: 128, nullable: true })
+  @Column({ type: 'varchar', length: 128 })
   businessNumber!: string;
 
   /**

--- a/src/interfaces/payload.ts
+++ b/src/interfaces/payload.ts
@@ -1,0 +1,3 @@
+export interface Payload {
+  id: number;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { setupSwagger } from './util/swagger';
@@ -7,6 +7,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const port = 3000;
 
+  app.useGlobalPipes(new ValidationPipe());
   setupSwagger(app);
   await app.listen(port);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
## Background(배경지식)
#50 에 이어서 #46 코멘트 내용을 반영했습니다!

## Implementations(보충설명)

#50 에서 추가된 내용은 다음과 같습니다.
 
- [e2ebc49](https://github.com/rimo030/Repo-Server/pull/50/commits/e2ebc49492435c6c44e76493bede9094927ddf29) : **defaultStrategy 삭제** 
app.module에 passport `defaultStrategy` 옵션을 삭제.

- [137588f](https://github.com/rimo030/Repo-Server/pull/50/commits/137588fa618eff7062c96637db706aaef26d25b1) : **find withDeleted 옵션 추가**
탈퇴한 이메일은 가입할 수 없도록, 회원가입시 이메일 검색 조건에  withDeleted를 추가

- [18de058](https://github.com/rimo030/Repo-Server/pull/50/commits/18de058b2fee1c1a82ea9b2c5e303d9ff859b70d) : **DTO의 hassedPassword → password로 변경**
프론트엔드단에서 암호화된 비밀번호를 받는 것이 아니기 때문
회원가입시 이메일 검색 조건에 구조분해 할당, take 1 추가

-  [5165dfc](https://github.com/rimo030/Repo-Server/pull/50/commits/5165dfcd7058964bcadb2248a6d1b59cf53468d7) : **any return 타입을 별도의 인터페이스로 변경**
buyer와 seller의 local 전략의 인증 결과로 `BuyerAuthResult`, `SellerAuthResult`를 반환하도록 인터페이스를 정의
